### PR TITLE
introspection performance for big datasets

### DIFF
--- a/R/inq_dim.R
+++ b/R/inq_dim.R
@@ -51,7 +51,7 @@ inq_dim.ZarrGroup <- function(z, dim) {
 
   rep_var <- get_rep_var(z, dim_name)
 
-  rep_var_len <- get_array_dims(z$get_item(rep_var))
+  rep_var_len <- get_array_dims(z, rep_var)
 
   rep_var_len <- rep_var_len$length[which(rep_var_len$name == dim_name)]
 

--- a/rnz.Rproj
+++ b/rnz.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 91919a08-5c1b-4f0a-ac96-03499513718b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -11,11 +11,11 @@ test_that("utils", {
                  time = list(name = "time")
                ))
 
-  expect_equal(get_array_dims(z$get_item("pr"), TRUE),
+  expect_equal(get_array_dims(z, "pr", TRUE),
                list(name = c("time", "latitude", "longitude"),
                     length = c(12L, 33L, 81L)))
 
-  expect_equal(get_array_dims(z$get_item("pr"), FALSE),
+  expect_equal(get_array_dims(z, "pr", FALSE),
                list(name = c("time", "latitude", "longitude")))
 
   expect_equal(get_attributes(z, 0),


### PR DESCRIPTION
I found crazy slow performance when listing variables and attributes of a large dataset.

I'm not thrilled with the performance, but it'll do for now.

``` r
ti <- Sys.time()

url <- "https://usgs.osn.mghpcc.org/hytest/conus404/conus404_monthly.zarr"

z <- pizzarr::zarr_open(url)

ncmeta::nc_vars(z)
#> # A tibble: 162 × 5
#>       id name    type  ndims natts
#>    <dbl> <chr>   <chr> <int> <int>
#>  1     0 ACDEWC  <f4       3     6
#>  2     1 ACDRIPR <f4       3     6
#>  3     2 ACDRIPS <f4       3     6
#>  4     3 ACECAN  <f4       3     6
#>  5     4 ACEDIR  <f4       3     6
#>  6     5 ACETLSM <f4       3     6
#>  7     6 ACETRAN <f4       3     6
#>  8     7 ACEVAC  <f4       3     6
#>  9     8 ACEVB   <f4       3     6
#> 10     9 ACEVC   <f4       3     6
#> # ℹ 152 more rows

ncmeta::nc_atts(z)
#> # A tibble: 957 × 4
#>       id name               variable value       
#>    <dbl> <chr>              <chr>    <named list>
#>  1     0 coordinates        ACDEWC   <chr [1]>   
#>  2     1 description        ACDEWC   <chr [1]>   
#>  3     2 grid_mapping       ACDEWC   <chr [1]>   
#>  4     3 integration_length ACDEWC   <chr [1]>   
#>  5     4 long_name          ACDEWC   <chr [1]>   
#>  6     5 units              ACDEWC   <chr [1]>   
#>  7     0 coordinates        ACDRIPR  <chr [1]>   
#>  8     1 description        ACDRIPR  <chr [1]>   
#>  9     2 grid_mapping       ACDRIPR  <chr [1]>   
#> 10     3 integration_length ACDRIPR  <chr [1]>   
#> # ℹ 947 more rows

Sys.time() - ti
#> Time difference of 32.60872 secs
```

<sup>Created on 2025-02-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
